### PR TITLE
Reduce Object Copying

### DIFF
--- a/opm/geomech/Fracture.hpp
+++ b/opm/geomech/Fracture.hpp
@@ -176,12 +176,14 @@ public:
     void setFractureGrid(std::unique_ptr<Fracture::Grid>& gptr); // a hack to allow use of another grid
     std::vector<std::tuple<int, double, double>> wellIndices() const;
     WellInfo& wellInfo(){return wellinfo_;}
+    const WellInfo& wellInfo() const {return wellinfo_;}
     std::vector<double> leakOfRate() const;
     double injectionPressure() const;
     void setPerfPressure(double perfpressure){perf_pressure_ = perfpressure;}
-    Dune::FieldVector<double, 6> stress(Dune::FieldVector<double, 3> obs) const;
-    Dune::FieldVector<double, 6> strain(Dune::FieldVector<double, 3> obs) const;
-    Dune::FieldVector<double, 3> disp(Dune::FieldVector<double, 3> obs) const;
+    Dune::FieldVector<double, 6> stress(const Dune::FieldVector<double, 3>& obs) const;
+    Dune::FieldVector<double, 6> strain(const Dune::FieldVector<double, 3>& obs) const;
+    Dune::FieldVector<double, 3> disp(const Dune::FieldVector<double, 3>& obs) const;
+
 private:
      Dune::BlockVector<Dune::FieldVector<double, 3>> all_slips() const;
     void resetWriters();

--- a/opm/geomech/FractureModel.cpp
+++ b/opm/geomech/FractureModel.cpp
@@ -1,206 +1,257 @@
 #include "config.h"
+
 #include <opm/geomech/FractureModel.hpp>
-#include <dune/common/fmatrixev.hh>
 #include <opm/geomech/DiscreteDisplacement.hpp>
+
+#include <dune/common/fmatrixev.hh>
+
 #include <opm/simulators/linalg/PropertyTree.hpp>
 
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <stddef.h>
+
 namespace Opm{
-    void FractureModel::addWell(std::string name,
-                           const std::vector<Point3D>& points,
-                           const std::vector<Segment>& segments,
-                           const std::vector<int>& res_cells){
-        std::string outputdir = prm_.get<std::string>("outputdir");
-        std::string casename = prm_.get<std::string>("casename"); 
-        wells_.push_back(FractureWell(outputdir,casename, name,points,segments, res_cells));
-        // add witth no fractures
-        well_fractures_.push_back(std::vector<Fracture>());
+    void FractureModel::addWell(const std::string& name,
+                                const std::vector<Point3D>& points,
+                                const std::vector<Segment>& segments,
+                                const std::vector<int>& res_cells)
+    {
+        const std::string outputdir = prm_.get<std::string>("outputdir");
+        const std::string casename = prm_.get<std::string>("casename");
+
+        wells_.emplace_back(outputdir, casename, name, points, segments, res_cells);
+
+        // add with no fractures
+        well_fractures_.emplace_back();
     }
 
-    void
-    FractureModel::addFractures()
+    void FractureModel::addFractures()
     {
-        auto config = prm_.get_child("config");
-        std::string type = config.get<std::string>("type");
-        for (size_t i = 0; i < wells_.size(); ++i) {
-            const FractureWell& well = wells_[i];
-            auto& grid = well.grid();
-            using ElementMapper = Dune::MultipleCodimMultipleGeomTypeMapper<FractureWell::Grid::LeafGridView>;
+        const auto config = prm_.get_child("config");
+        const std::string type = config.get<std::string>("type");
+
+        using ElementMapper = Dune::MultipleCodimMultipleGeomTypeMapper
+            <FractureWell::Grid::LeafGridView>;
+
+        auto wellFrac = this->well_fractures_.begin();
+        for (const auto& well : this->wells_) {
+            const auto& grid = well.grid();
+
             ElementMapper mapper(grid.leafGridView(), Dune::mcmgElementLayout());
             for (const auto& elem : elements(grid.leafGridView())) {
-                int eIdx = mapper.index(elem);
-                auto geo = elem.geometry();
+                const int eIdx = mapper.index(elem);
+                const auto geo = elem.geometry();
                 assert(geo.corners() == 2);
+
                 // auto origo = geo.center();
                 Dune::FieldVector<double, 3> origo, normal;
                 int perf = eIdx;
-                
                 int well_cell = well.reservoirCell(eIdx);
 
                 if (type == "perp_well") {
-		  origo = geo.corner(1); // assume this is cell center
-		  normal = geo.corner(1) - geo.corner(0);
-		  // perf = well_fractures_[i].size();
-		} else if (type == "well_seed") {
-		  if( config.get<std::string>("well") == well.name()){
-		    std::cout << "Fracure added for well " << well.name() << std::endl;
-		    //std::vector<int> cell_ijk = config.get< std::vector<int> > ("cell_ijk");
-		    int cell = config.get< int> ("cell");
-		    if(well.reservoirCell(eIdx) == cell){
-		      origo = geo.corner(1);
-		      auto config_bst = config.getBoostParamPtr();
-		      //double tmp = config_bst->get<double > ("normal",1);
-		      //for (auto i : as_vector<int>(pt, "a")) std::cout << i << ' ';
-		      std::vector<double> tmp_normal = as_vector<double>(*config_bst,"normal");
-		      assert(tmp_normal.size() == 3); // wrong use of tmpmal.
-		      for(int i=0; i < 3; ++i){
-			normal[i] = tmp_normal[i];
-		      }
-		    }else{
-		      continue;
-		    }
-		  }else{
-		    continue;
-		  }
-                } else if (type == "tensile_fracture") {
-		  // https://link.springer.com/article/10.1007/s40948-023-00694-1
-		  double fractureThoughness = 1.0e6; // reservoir_fractureThoughness_[eIdx]; // ca 1.0 MPa m^1/2
-		  double tensilestrength = 5e6; // reservoir_tensilestrength_[eIdx]; //  5 MPa
-		  double criticallength = (fractureThoughness / tensilestrength); // ca (1/5)^2 5 mm.
-		  criticallength *= criticallength;
-		  auto stressmat = ddm::symTensor2Matrix(well.reservoirStress(eIdx));
-		  Dune::FieldMatrix<double, 3, 3> eigenVectors;
-		  Dune::FieldVector<double, 3> eigenValues;
-		  Dune::FMatrixHelp::eigenValuesVectors(stressmat, eigenValues, eigenVectors);
-		  int min_dir = -1;
-		  int max_dir = -1;
-		  double min_eig = 1e99;
-		  double max_eig = -1e99;
-		  for (int i = 0; i < 3; ++i) {
-		    if (eigenValues[i] < min_eig) {
-		      min_dir = i;
-		      min_eig = eigenValues[i];
-		    }
-		    if (eigenValues[i] > max_eig) {
-		      max_dir = i;
-		      max_eig = eigenValues[i];
-		    }
-		  }
-		  normal = eigenVectors[min_dir];
-		  // take midpoint
-		  origo = geo.corner(1); //-geo.corner(0);
-		  // origo /= 2.0;
-		  //  expression for size;
-                } else {
-		  OPM_THROW(std::runtime_error, "Invalid fracture type");
+                    origo = geo.corner(1); // assume this is cell center
+                    normal = geo.corner(1) - geo.corner(0);
+                    // perf = well_fractures_[i].size();
+		}
+                else if (type == "well_seed") {
+                    if (config.get<std::string>("well") == well.name()) {
+                        std::cout << "Fracure added for well " << well.name() << std::endl;
+                        //std::vector<int> cell_ijk = config.get< std::vector<int> > ("cell_ijk");
+                        int cell = config.get< int> ("cell");
+                        if (well.reservoirCell(eIdx) == cell) {
+                            origo = geo.corner(1);
+                            auto config_bst = config.getBoostParamPtr();
+                            //double tmp = config_bst->get<double > ("normal",1);
+                            //for (auto i : as_vector<int>(pt, "a")) std::cout << i << ' ';
+                            std::vector<double> tmp_normal = as_vector<double>(*config_bst,"normal");
+                            assert(tmp_normal.size() == 3); // wrong use of tmpmal.
+                            for (int i=0; i < 3; ++i) {
+                                normal[i] = tmp_normal[i];
+                            }
+                        }
+                        else {
+                            continue;
+                        }
+                    }
+                    else {
+                        continue;
+                    }
+                }
+                else if (type == "tensile_fracture") {
+                    // https://link.springer.com/article/10.1007/s40948-023-00694-1
+                    const double fractureThoughness = 1.0e6; // reservoir_fractureThoughness_[eIdx]; // ca 1.0 MPa m^1/2
+                    const double tensilestrength = 5e6; // reservoir_tensilestrength_[eIdx]; //  5 MPa
+
+                    double criticallength = (fractureThoughness / tensilestrength); // ca (1/5)^2 5 mm.
+                    criticallength *= criticallength;
+
+                    Dune::FieldMatrix<double, 3, 3> eigenVectors;
+                    Dune::FieldVector<double, 3> eigenValues;
+                    auto stressmat = ddm::symTensor2Matrix(well.reservoirStress(eIdx));
+                    Dune::FMatrixHelp::eigenValuesVectors(stressmat, eigenValues, eigenVectors);
+
+                    int min_dir = -1;
+                    int max_dir = -1;
+                    double min_eig = 1e99;
+                    double max_eig = -1e99;
+                    for (int i = 0; i < 3; ++i) {
+                        if (eigenValues[i] < min_eig) {
+                            min_dir = i;
+                            min_eig = eigenValues[i];
+                        }
+                        if (eigenValues[i] > max_eig) {
+                            max_dir = i;
+                            max_eig = eigenValues[i];
+                        }
+                    }
+
+                    normal = eigenVectors[min_dir];
+
+                    // take midpoint
+                    origo = geo.corner(1); //-geo.corner(0);
+                    // origo /= 2.0;
+                    //  expression for size;
+                }
+                else {
+                    OPM_THROW(std::runtime_error, "Invalid fracture type");
                 }
 
+                wellFrac->emplace_back()
+                    .init(well.name(), perf, well_cell, origo, normal, prm_);
+            }
 
-                Fracture fracture;
-                fracture.init(well.name(), perf, well_cell, origo, normal, prm_);
-                well_fractures_[i].push_back(std::move(fracture));
+            ++wellFrac;
+        }
+    }
+
+    void FractureModel::initFractureStates()
+    {
+        for (auto& fractures : this->well_fractures_) {
+            for (auto& fracture : fractures) {
+                fracture.initFractureStates();
             }
         }
     }
 
-    void FractureModel::initFractureStates(){
-        for(size_t i=0; i < wells_.size(); ++i){
-            std::vector<Fracture>& fractures = well_fractures_[i];
-            for(size_t j=0; j < fractures.size(); ++j){
-                fractures[j].initFractureStates();
-            }
-        }
-    }
     // probably this should be collected in one loop
-    Dune::FieldVector<double,6> FractureModel::stress(Dune::FieldVector<double,3> obs) const{
-        Dune::FieldVector<double,6> stress;
-        for(size_t i=0; i < wells_.size(); ++i){
-            const std::vector<Fracture>& fractures = well_fractures_[i];
-            for(size_t j=0; j < fractures.size(); ++j){
-                Dune::FieldVector<double,6> tmp = fractures[j].stress(obs);
-                stress += tmp;
+    Dune::FieldVector<double,6>
+    FractureModel::stress(const Dune::FieldVector<double,3>& obs) const
+    {
+        Dune::FieldVector<double,6> stress{};
+
+        for (const auto& fractures : this->well_fractures_) {
+            for (const auto& fracture : fractures) {
+                stress += fracture.stress(obs);
             }
         }
+
         return stress;
     }
-    Dune::FieldVector<double,6> FractureModel::strain(Dune::FieldVector<double,3> obs) const{
-        Dune::FieldVector<double,6> strain;
-        for(size_t i=0; i < wells_.size(); ++i){
-            const std::vector<Fracture>& fractures = well_fractures_[i];
-            for(size_t j=0; j < fractures.size(); ++j){
-                Dune::FieldVector<double,6> tmp = fractures[j].strain(obs);
-                strain += tmp;
+
+    Dune::FieldVector<double,6>
+    FractureModel::strain(const Dune::FieldVector<double,3>& obs) const
+    {
+        Dune::FieldVector<double,6> strain{};
+
+        for (const auto& fractures : this->well_fractures_) {
+            for (const auto& fracture : fractures) {
+                strain += fracture.strain(obs);
             }
         }
+
         return strain;
     }
-    Dune::FieldVector<double,3> FractureModel::disp(Dune::FieldVector<double,3> obs) const{
-        Dune::FieldVector<double,3> disp;
-        for(size_t i=0; i < wells_.size(); ++i){
-            const std::vector<Fracture>& fractures = well_fractures_[i];
-            for(size_t j=0; j < fractures.size(); ++j){
-                Dune::FieldVector<double,3> tmp = fractures[j].disp(obs);
-                disp += tmp;
+
+    Dune::FieldVector<double,3>
+    FractureModel::disp(const Dune::FieldVector<double,3>& obs) const
+    {
+        Dune::FieldVector<double,3> disp{};
+
+        for (const auto& fractures : this->well_fractures_) {
+            for (const auto& fracture : fractures) {
+                disp += fracture.disp(obs);
             }
         }
+
         return disp;
-
     }
 
-    void FractureModel::write(int reportStep) const{
-        for(size_t i=0; i < wells_.size(); ++i){
-            wells_[i].write();
-            const std::vector<Fracture>& fractures = well_fractures_[i];
-            for(size_t j=0; j < fractures.size(); ++j){
-                fractures[j].write(reportStep);
+    void FractureModel::write(int reportStep) const
+    {
+        for (auto i = 0*this->wells_.size(); i < this->wells_.size(); ++i) {
+            this->wells_[i].write();
+
+            for (const auto& fracture : this->well_fractures_[i]) {
+                fracture.write(reportStep);
             }
         }
     }
-    void FractureModel::writemulti(double time) const{
-        for(size_t i=0; i < wells_.size(); ++i){
-            wells_[i].writemulti(time);
-            const std::vector<Fracture>& fractures = well_fractures_[i];
-            for(size_t j=0; j < fractures.size(); ++j){
-                fractures[j].writemulti(time);
+
+    void FractureModel::writemulti(double time) const
+    {
+        for (auto i = 0*this->wells_.size(); i < this->wells_.size(); ++i) {
+            this->wells_[i].writemulti(time);
+
+            for (const auto& fracture : this->well_fractures_[i]) {
+                fracture.writemulti(time);
             }
         }
     }
-    void FractureModel::solve() {
-        for(size_t i=0; i < wells_.size(); ++i){
-            std::vector<Fracture>& fractures = well_fractures_[i];
-            for(size_t j=0; j < fractures.size(); ++j){
-                fractures[j].solve();
+
+    void FractureModel::solve()
+    {
+        for (auto& fractures : this->well_fractures_) {
+            for (auto& fracture : fractures) {
+                fracture.solve();
             }
         }
     }
-    void FractureModel::updateReservoirProperties() {
-        for(size_t i=0; i < wells_.size(); ++i){
-            std::vector<Fracture>& fractures = well_fractures_[i];
-            for(size_t j=0; j < fractures.size(); ++j){
-                fractures[j].updateReservoirProperties();
+
+    void FractureModel::updateReservoirProperties()
+    {
+        for (auto& fractures : this->well_fractures_) {
+            for (auto& fracture : fractures) {
+                fracture.updateReservoirProperties();
             }
         }
     }
+
     std::vector<std::tuple<int,double,double>> 
-    FractureModel::getExtraWellIndices(std::string wellname) const{
-        // for now just do a search
-        bool addconnections = prm_.get<bool>("addconnections");
-        if (addconnections) {
-            for (size_t i = 0; i < wells_.size(); ++i) {
-                if (wells_[i].name() == wellname) {
-                    // collect all from a well
-                    std::vector<std::tuple<int, double, double>> wellindices;
-                    for (const auto& frac : well_fractures_[i]) {
-                        auto perfs = frac.wellIndices();
-                        wellindices.insert(wellindices.begin(),perfs.begin(), perfs.end());
-                    }
-                    return wellindices;
-                }
-            }
-            std::string message = "Now fractures on this well found";
-            message += wellname;
-            OPM_THROW(std::runtime_error, message.c_str());
+    FractureModel::getExtraWellIndices(const std::string& wellname) const
+    {
+        auto wellindices = std::vector<std::tuple<int, double, double>>{};
+
+        if (! prm_.get<bool>("addconnections")) {
+            return wellindices;
         }
-        std::vector<std::tuple<int, double, double>> empty; 
-        return empty;
+
+        // For now just do a search
+        auto pos = std::find_if(this->wells_.begin(), this->wells_.end(),
+                                [&wellname](const auto& well)
+                                { return well.name() == wellname; });
+
+        if (pos == this->wells_.end()) {
+            OPM_THROW(std::runtime_error, "No fractures found for well " + wellname);
+        }
+
+        const auto i = std::distance(this->wells_.begin(), pos);
+        for (const auto& frac : well_fractures_[i]) {
+            auto perfs = frac.wellIndices();
+
+            wellindices.insert(wellindices.begin(),
+                               std::make_move_iterator(perfs.begin()),
+                               std::make_move_iterator(perfs.end()));
+        }
+
+        return wellindices;
     }
 }

--- a/opm/geomech/FractureModel.hpp
+++ b/opm/geomech/FractureModel.hpp
@@ -2,24 +2,32 @@
 #include "Fracture.hpp"
 #include "FractureWell.hpp"
 #include "GeometryHelpers.hpp"
+
 #include <opm/grid/common/CartesianIndexMapper.hpp>
 #include <opm/grid/utility/compressedToCartesian.hpp>
 #include <opm/grid/utility/cartesianToCompressed.hpp>
+
 #include <opm/input/eclipse/Schedule/Well/Connection.hpp>
 #include <opm/input/eclipse/Schedule/Well/Well.hpp>
 #include <opm/input/eclipse/Schedule/Well/WellConnections.hpp>
+
 #include <opm/simulators/linalg/PropertyTree.hpp>
+
 #include <iostream>
 #include <sstream>
 #include <string>
+
 #include <boost/property_tree/ptree.hpp>
+
 using ptree = boost::property_tree::ptree;
 template <typename T>
 std::vector<T> as_vector(ptree const& pt, ptree::key_type const& key)
 {
     std::vector<T> r;
-    for (auto& item : pt.get_child(key))
+    for (const auto& item : pt.get_child(key)) {
         r.push_back(item.second.get_value<T>());
+    }
+
     return r;
 }
 
@@ -31,8 +39,9 @@ std::vector<T> as_vector(ptree const& pt, ptree::key_type const& key)
 //       r.push_back(item.second.get_value<T>());
 //     return r;
 // }
-namespace Opm{
-class FractureModel{
+namespace Opm {
+class FractureModel
+{
     //using CartesianIndexMapper = Dune::CartesianIndexMapper<Dune::CpGrid>;
 public:
     using Point3D = Dune::FieldVector<double,3>;
@@ -40,8 +49,8 @@ public:
     template<class Grid>
     FractureModel(const Grid& grid,
                   const std::vector<Opm::Well>& wells,
-                   const Opm::PropertyTree&
-        );
+                  const Opm::PropertyTree& param);
+
     void addFractures();
 
     template <class Grid>
@@ -75,18 +84,24 @@ public:
             }
         }
     }
-    void addWell(std::string name, const std::vector<Point3D>& points,const std::vector<std::array<unsigned,2>>& segments,const std::vector<int>& reservoir_cells );
+
+    void addWell(const std::string& name,
+                 const std::vector<Point3D>& points,
+                 const std::vector<std::array<unsigned,2>>& segments,
+                 const std::vector<int>& reservoir_cells);
+
     void write(int ReportStep = -1) const;
     void writemulti(double time) const;
     void solve();
     void updateReservoirProperties();
     void initFractureStates();
+
     template <class TypeTag, class Simulator>
     void initReservoirProperties(const Simulator& simulator)
     {
-        for (size_t i=0; i < wells_.size(); ++i) {
-            for (auto& fracture : well_fractures_[i]){
-                fracture.initReservoirProperties<TypeTag, Simulator>(simulator);
+        for (auto& fractures : this->well_fractures_) {
+            for (auto& fracture : fractures) {
+                fracture.initReservoirProperties<TypeTag>(simulator);
             }
         }
     }
@@ -96,21 +111,20 @@ public:
     {
         for (size_t i=0; i < wells_.size(); ++i) {
             for (auto& fracture : well_fractures_[i]){
-                fracture.updateReservoirProperties<TypeTag, Simulator>(simulator);
+                fracture.updateReservoirProperties<TypeTag>(simulator);
                 // set well properties
-                WellInfo wellinfo = fracture.wellInfo();
+                const auto& wellinfo = fracture.wellInfo();
                 // need to be double checked how to assosiate correct perforation/segment
-                int perf_index_frac = wellinfo.perf;
-                int cell_index_frac = wellinfo.well_cell;
-                std::size_t well_index = simulator.problem().wellModel().wellState().index(wellinfo.name).value();
-                const auto& wellstate = simulator.problem().wellModel().wellState().well(well_index);
+                const int perf_index_frac = wellinfo.perf;
+                const int cell_index_frac = wellinfo.well_cell;
+                const auto& wellstate = simulator.problem().wellModel().wellState().well(wellinfo.name);
                 const auto& perf_data = wellstate.perf_data;
                 auto it = std::find(perf_data.cell_index.begin(),
                                     perf_data.cell_index.end(),
                                     cell_index_frac);
-                int perf_index = it- perf_data.cell_index.begin();
+                const int perf_index = it- perf_data.cell_index.begin();
                 std::cout << "Perf index flow " << perf_index << " fracture " << perf_index_frac << std::endl;
-                double perf_pressure = perf_data.pressure[perf_index];
+                const double perf_pressure = perf_data.pressure[perf_index];
                 fracture.setPerfPressure(perf_pressure);
                 wells_[i].setPerfPressure(perf_index_frac, perf_pressure);
                 //NB do we need some rates? need to be summed over "peforations of the fractures"
@@ -118,22 +132,29 @@ public:
         }
     }
 
-    template<class TypeTag, class Simulator>
-    void updateReservoirWellProperties(const Simulator& simulator) {
-        for(auto& well : wells_){
-             well.updateReservoirProperties<TypeTag,Simulator>(simulator);
+    template <class TypeTag, class Simulator>
+    void updateReservoirWellProperties(const Simulator& simulator)
+    {
+        for (auto& well : wells_) {
+            well.updateReservoirProperties<TypeTag>(simulator);
         }
     }
-    std::vector<std::tuple<int,double,double>> getExtraWellIndices(std::string wellname) const;
+
+    std::vector<std::tuple<int,double,double>>
+    getExtraWellIndices(const std::string& wellname) const;
+
     bool addPertsToSchedule(){return prm_.get<bool>("addperfs_to_schedule");}
+
     // probably this should be collected in one loop since all do full loop over fracture ++ well
-    Dune::FieldVector<double,6> stress(Dune::FieldVector<double,3> obs) const;
-    Dune::FieldVector<double,6> strain(Dune::FieldVector<double,3> obs) const;
-    Dune::FieldVector<double,3> disp(Dune::FieldVector<double,3> obs) const;
+    Dune::FieldVector<double,6> stress(const Dune::FieldVector<double,3>& obs) const;
+    Dune::FieldVector<double,6> strain(const Dune::FieldVector<double,3>& obs) const;
+    Dune::FieldVector<double,3> disp(const Dune::FieldVector<double,3>& obs) const;
+
 private:
     std::vector<FractureWell> wells_;
     std::vector<std::vector<Fracture>> well_fractures_;
     Opm::PropertyTree prm_;
 };
 }
+
 #include "FractureModel_impl.hpp"

--- a/opm/geomech/FractureModel_impl.hpp
+++ b/opm/geomech/FractureModel_impl.hpp
@@ -3,83 +3,81 @@
 namespace Opm{
     template<class Grid>
     FractureModel::FractureModel(const Grid& grid,
-                  const std::vector<Opm::Well>& wells,
-                  const Opm::PropertyTree& param)
-                  :
-        prm_(param)
+                                 const std::vector<Opm::Well>& wells,
+                                 const Opm::PropertyTree& param)
+        : prm_(param)
     {
-      using CartesianIndexMapper = Dune::CartesianIndexMapper<Grid>;
-      CartesianIndexMapper cartmapper(grid);
-      const auto& cartdim = cartmapper.cartesianDimensions();
-      std::vector<int> cart(cartdim[0]*cartdim[1]*cartdim[2], -1);
-      using ElementMapper = Dune::MultipleCodimMultipleGeomTypeMapper<typename Grid::LeafGridView>;
-      ElementMapper mapper(grid.leafGridView(), Dune::mcmgElementLayout());
-      for (const auto& elem : elements(grid.leafGridView())) {
-	int eIdx = mapper.index(elem);
-	cart[ cartmapper.cartesianIndex( eIdx ) ] = eIdx;
-      }
-      const auto& config = prm_.get_child("config");
-      std::string type = config.get<std::string>("type");
-      if( type  == "well_seed"){
-	auto config_bst = prm_.getBoostParamPtr();
-	std::vector<int> cell_ijk = as_vector<int>(*config_bst, "config.cell_ijk");
-	std::array<int, 3> ijk;
-	   assert(cell_ijk.size() == 3);
-	for(int i=0; i < 3; ++i){
-	  // map to 0 based
-	  ijk[i] = cell_ijk[i]-1;
-	}
-	int cartIdx =  ijk[0]+(cartdim[0])*ijk[1]+(cartdim[0]*cartdim[1])*ijk[2];//NB assumes ijk ordering
-	int reservoir_cell = cart[cartIdx];
-	assert(cartIdx>=0);
-	prm_.put("config.cell",reservoir_cell);
-      }
-      
-     
+        using CartesianIndexMapper = Dune::CartesianIndexMapper<Grid>;
+        CartesianIndexMapper cartmapper(grid);
+        const auto& cartdim = cartmapper.cartesianDimensions();
+        std::vector<int> cart(cartdim[0]*cartdim[1]*cartdim[2], -1);
+        using ElementMapper = Dune::MultipleCodimMultipleGeomTypeMapper<typename Grid::LeafGridView>;
+        ElementMapper mapper(grid.leafGridView(), Dune::mcmgElementLayout());
+        for (const auto& elem : elements(grid.leafGridView())) {
+            const int eIdx = mapper.index(elem);
+            cart[ cartmapper.cartesianIndex(eIdx) ] = eIdx;
+        }
+        const auto& config = prm_.get_child("config");
+        std::string type = config.get<std::string>("type");
+        if (type  == "well_seed"){
+            auto config_bst = prm_.getBoostParamPtr();
+            std::vector<int> cell_ijk = as_vector<int>(*config_bst, "config.cell_ijk");
+            std::array<int, 3> ijk;
+            assert(cell_ijk.size() == 3);
+            for(int i=0; i < 3; ++i){
+                // map to 0 based
+                ijk[i] = cell_ijk[i]-1;
+            }
+            int cartIdx = ijk[0] + cartdim[0]*(ijk[1] + cartdim[1]*ijk[2]);//NB assumes ijk ordering
+            int reservoir_cell = cart[cartIdx];
+            assert(cartIdx>=0);
+            prm_.put("config.cell",reservoir_cell);
+        }
+
         //using CartesianIndexMapper = Dune::CartesianIndexMapper<Grid>;
         //CartesianIndexMapper cartmapper(grid);
         //const std::array<int, dimension>
         //auto cartdims = cartmapper.cartesianDimensions();
         GeometryHelper geomhelp(grid);
-	// NB: need to be carefull in parallel
+        // NB: need to be carefull in parallel
         for(int wellIdx=0; wellIdx < wells.size(); ++wellIdx){
             std::vector<Point3D> vertices;
             std::vector<Segment> wellsegment;
             auto well = wells[wellIdx];
             if(true){//well.isInjector()){// only look at injectors
-            std::vector<int> cells;
-            // should be done property with welltraj
-            for(const auto& connection : well.getConnections()){
-                int global_index = connection.global_index();
-                int cell_index = geomhelp.compressedIndex(global_index);
-                Point3D vertex = geomhelp.centroid(cell_index);
-                vertices.push_back(vertex);
-                cells.push_back(cell_index);
-            }
-            Point3D refpoint(vertices[0]);
-            if(well.hasRefDepth()){
-                if(std::abs(well.getRefDepth()-refpoint[2])< 10){
-                    refpoint[2] = well.getRefDepth()-10;//avoid zero
-                }else{
-                    refpoint[2] = well.getRefDepth();
+                std::vector<int> cells;
+                // should be done property with welltraj
+                for(const auto& connection : well.getConnections()){
+                    int global_index = connection.global_index();
+                    int cell_index = geomhelp.compressedIndex(global_index);
+                    Point3D vertex = geomhelp.centroid(cell_index);
+                    vertices.push_back(vertex);
+                    cells.push_back(cell_index);
                 }
-            }else{
-                refpoint[2] -= 10;
-            }
-            vertices.insert(vertices.begin(),refpoint);
-            std::vector<Segment> segments;
-            //NB unsinged so grid can not be to big
-            for(unsigned i=0; i < unsigned(cells.size()); ++i){
-                segments.push_back(Segment({i,i+1}));
-            }
-            // NB should add gri cells
-            this->addWell(well.name(),vertices, segments, cells);
+                Point3D refpoint(vertices[0]);
+                if(well.hasRefDepth()){
+                    if(std::abs(well.getRefDepth()-refpoint[2])< 10){
+                        refpoint[2] = well.getRefDepth()-10;//avoid zero
+                    }else{
+                        refpoint[2] = well.getRefDepth();
+                    }
+                }else{
+                    refpoint[2] -= 10;
+                }
+                vertices.insert(vertices.begin(),refpoint);
+                std::vector<Segment> segments;
+                //NB unsinged so grid can not be to big
+                for(unsigned i=0; i < unsigned(cells.size()); ++i){
+                    segments.push_back(Segment({i,i+1}));
+                }
+                // NB should add gri cells
+                this->addWell(well.name(),vertices, segments, cells);
             }
         }
     }
     template<class Grid>
     void FractureModel::addDefaultsWells(const Grid& grid, const Opm::EclipseGrid& eclgrid){
-            this->addFractures();
-            this->updateFractureReservoirCells(grid,eclgrid);
+        this->addFractures();
+        this->updateFractureReservoirCells(grid,eclgrid);
     }
 }

--- a/opm/geomech/FractureWell.cpp
+++ b/opm/geomech/FractureWell.cpp
@@ -1,42 +1,58 @@
 #include "config.h"
+
 #include <opm/geomech/FractureWell.hpp>
+
 #include <dune/geometry/referenceelements.hh>
-namespace Opm{
+
+namespace Opm {
     void FractureWell::init(const std::vector<Point3D>& points,
-                   const std::vector<Segment>& segments){
-        Dune::GridFactory<Grid> factory;
-        for(size_t i=0; i < points.size(); ++i){
-            factory.insertVertex(points[i]);
+                            const std::vector<Segment>& segments)
+    {
+        Dune::GridFactory<Grid> factory{};
+
+        for (const auto& vertex : points) {
+            factory.insertVertex(vertex);
         }
-        for (size_t i = 0; i < segments.size(); ++i) {
+
+        for (const auto& segment : segments) {
             std::vector<unsigned int> seg(2,0);
-            seg[0] = segments[i][0];seg[1] = segments[i][1];
+            seg[0] = segment[0];
+            seg[1] = segment[1];
+
             factory.insertElement(Dune::GeometryTypes::line, seg); // std::move(mapping));
         }
+
         grid_ = factory.createGrid();
+
         this->resetWriters();
     }
 
-    void FractureWell::write() const{
-        std::string filename = outputprefix_ + "/" + this->name();
-        vtkwriter_->write(filename.c_str());
+    void FractureWell::write() const
+    {
+        const std::string filename = outputprefix_ + "/" + this->name();
+        vtkwriter_->write(filename);
     }
 
-    void FractureWell::resetWriters(){
+    void FractureWell::resetWriters()
+    {
         // nead to be reseat if grid is changed ??
-        vtkwriter_ = std::make_unique<Dune::VTKWriter<Grid::LeafGridView>>(grid_->leafGridView(), Dune::VTK::nonconforming);
-        std::string outputdir = outputprefix_;
-        std::string simName = casename_ + "_" + this->name();
-        std::string multiFileName =  "";
-        vtkmultiwriter_ = std::make_unique< Opm::VtkMultiWriter<Grid::LeafGridView, VTKFormat > >(/*async*/ false,
-                                                                                              grid_->leafGridView(),
-                                                                                              outputdir,
-                                                                                              simName,
-                                                                                              multiFileName
-        );
+        vtkwriter_ = std::make_unique<Dune::VTKWriter<Grid::LeafGridView>>
+            (grid_->leafGridView(), Dune::VTK::nonconforming);
+
+        const std::string outputdir = outputprefix_;
+        const std::string simName = casename_ + "_" + this->name();
+        const std::string multiFileName =  "";
+
+        vtkmultiwriter_ = std::make_unique<VtkMultiWriter<Grid::LeafGridView, VTKFormat>>
+            (/*async*/ false,
+             grid_->leafGridView(),
+             outputdir,
+             simName,
+             multiFileName);
     }
 
-    void FractureWell::writemulti(double time) const{
+    void FractureWell::writemulti(const double time) const
+    {
         std::vector<double> reservoir_pressure = reservoir_pressure_;
         std::vector<double> reservoir_temperature = reservoir_temperature_;
         //std::vector<double> reservoir_cells = reservoir_cells_;
@@ -54,21 +70,25 @@ namespace Opm{
         vtkmultiwriter_->endWrite();
     }
 
-    FractureWell::FractureWell(std::string outputprefix,
-                               std::string casename, 
-                           std::string name,
-                           const std::vector<Point3D>& points,
-                           const std::vector<Segment>& segments,
-                           const std::vector<int>& res_cells){
-                            outputprefix_ = outputprefix;
-                            casename_ = casename;
+    FractureWell::FractureWell(const std::string& outputprefix,
+                               const std::string& casename,
+                               const std::string& name,
+                               const std::vector<Point3D>& points,
+                               const std::vector<Segment>& segments,
+                               const std::vector<int>& res_cells)
+    {
+        outputprefix_ = outputprefix;
+        casename_ = casename;
         name_ = name;
+
         this->init(points, segments);
+
         vtkwriter_ =
             std::make_unique<Dune::VTKWriter<Grid::LeafGridView>>
             (grid_->leafGridView(), Dune::VTK::nonconforming);
+
         reservoir_cells_ = res_cells;
         reservoir_stress_.resize(res_cells.size());
-        std::fill(reservoir_stress_.begin(),reservoir_stress_.end(),100e5);// random initialization    
+        std::fill(reservoir_stress_.begin(), reservoir_stress_.end(), 100.0e5); // random initialization
     }
 }

--- a/opm/geomech/FractureWell.hpp
+++ b/opm/geomech/FractureWell.hpp
@@ -7,9 +7,9 @@ class FractureWell
     using Segment = std::array<unsigned,2>;
 public:
     using Grid = Dune::FoamGrid<1,3>;
-    FractureWell(std::string outputprefix,
-                 std::string casename,
-                 std::string name,
+    FractureWell(const std::string& outputprefix,
+                 const std::string& casename,
+                 const std::string& name,
                  const std::vector<Point3D>& points,
                  const std::vector<Segment>& segments,
                  const std::vector<int>& res_cells);
@@ -43,12 +43,18 @@ public:
     }
     void setPerfPressure(int perf_index, double pressure){perf_pressure_[perf_index] = pressure;}
     const Grid& grid() const{return *grid_;}
-    std::string name() const{return name_;};
+    const std::string& name() const{return name_;};
     void write() const;
     void writemulti(double time) const;
     void resetWriters();
-    int reservoirCell(int wellcell) const {return reservoir_cells_[wellcell];};
-    Dune::FieldVector<double,6> reservoirStress(int wellcell) const{return reservoir_stress_[wellcell];};
+    int reservoirCell(int wellcell) const {return reservoir_cells_[wellcell];}
+
+    const Dune::FieldVector<double,6>&
+    reservoirStress(int wellcell) const
+    {
+        return reservoir_stress_[wellcell];
+    }
+
 private:
     std::string outputprefix_;
     std::string casename_;

--- a/opm/geomech/eclgeomechmodel.hh
+++ b/opm/geomech/eclgeomechmodel.hh
@@ -83,35 +83,32 @@ namespace Opm{
                     include_fracture_contributions_ = param.get<bool>("include_fracture_contributions");
                     //param.read("fractureparam.json");
                     const auto& schedule =  this->simulator_.vanguard().schedule();
-                    int reportStepIdx = simulator_.episodeIndex();
+                    const int reportStepIdx = simulator_.episodeIndex();
                     const std::vector<Opm::Well>& wells = problem.wellModel().getLocalWells(reportStepIdx);
                     //const std::vector<Opm::Well>& wells = schedule.getWells(reportStepIdx);
                     //const Opm::EclipseGrid& eclgrid = simulator_.vanguard().eclState().getInputGrid();
                     const auto& grid = simulator_.vanguard().grid();
-                    std::string outputDir = Parameters::Get<Parameters::OutputDir>();
-                    std::string caseName  = simulator_.vanguard().caseName();
+                    const std::string outputDir = Parameters::Get<Parameters::OutputDir>();
+                    const std::string caseName  = simulator_.vanguard().caseName();
                     param.put("outputdir", outputDir);
                     param.put("casename", caseName);
 
-                    fracturemodel_ = std::make_unique<FractureModel>(grid,
-                                                                     wells,
-                                                                     param
-                        );
+                    fracturemodel_ = std::make_unique<FractureModel>
+                        (grid, wells, param);
                     // not to get the reservoir properties along the well before initialising the well
                     // most important stress
-                    fracturemodel_->updateReservoirWellProperties<TypeTag,Simulator>(simulator_);
+                    fracturemodel_->updateReservoirWellProperties<TypeTag>(simulator_);
                     // add fractures along the wells
                     fracturemodel_->addFractures();
 
                     //fracturemodel_->updateFractureReservoirCells(grid, eclgrid);
                     fracturemodel_->updateFractureReservoirCells(grid);
-                    fracturemodel_->initReservoirProperties<TypeTag,Simulator>(simulator_);
-                    fracturemodel_->updateReservoirProperties<TypeTag,Simulator>(simulator_);
+                    fracturemodel_->initReservoirProperties<TypeTag>(simulator_);
+                    fracturemodel_->updateReservoirProperties<TypeTag>(simulator_);
                     fracturemodel_->initFractureStates();
                 }
-                // get reservoir properties on fractures
-                // simulator need
-                fracturemodel_->updateReservoirProperties<TypeTag,Simulator>(simulator_);
+                // get reservoir properties on fractures simulator need
+                fracturemodel_->updateReservoirProperties<TypeTag>(simulator_);
                 fracturemodel_->solve();
                 // copy from apply action
             }
@@ -131,7 +128,9 @@ namespace Opm{
 
         }
 
-        std::vector<std::tuple<int,double,double>> getExtraWellIndices(std::string wellname){
+        std::vector<std::tuple<int,double,double>>
+        getExtraWellIndices(const std::string& wellname) const
+        {
             return fracturemodel_->getExtraWellIndices(wellname);
         }
 
@@ -213,6 +212,7 @@ namespace Opm{
                     elacticitysolver_.A.getLoadVector(),
                     elacticitysolver_.comm());
                     {
+                        const auto& problem = simulator_.problem();
                         int num_points = simulator_.vanguard().grid().size(3);
                         Dune::BlockVector<Dune::FieldVector<double,1>> fixed(3*num_points);
                         fixed  = 0.0;

--- a/opm/geomech/eclproblemgeomech.hh
+++ b/opm/geomech/eclproblemgeomech.hh
@@ -267,7 +267,6 @@ namespace Opm{
             }
             
             Parent::endStepApplyAction();
- 
         }
 
         void addConnectionsToWell(){
@@ -294,11 +293,9 @@ namespace Opm{
             //auto mapper = simulator.vanguard().cartesianMapper();
             auto& wellcontainer = this->wellModel().localNonshutWells();
             for (auto& wellPtr : wellcontainer) {
-                auto wellName = wellPtr->name();
-                const auto& wellcons = geomechModel_.getExtraWellIndices(wellName);
-                for (const auto& cons : wellcons) {
-                    // simple calculated with upscaling
-                    const auto [cell, WI, depth] = cons;
+                const auto& wellName = wellPtr->name();
+                auto& ePerfs = extra_perfs[wellName];
+                for (const auto& [cell, WI, depth] : geomechModel_.getExtraWellIndices(wellName)) {
                     // map to cartesian
                     const auto cartesianIdx = simulator.vanguard().cartesianIndex(cell);
                     // get ijk
@@ -321,7 +318,7 @@ namespace Opm{
                                                /*sort_value*/ -1,
                                                /*defaut sattable*/ true);
                     connection.setCF(WI);
-                    extra_perfs[wellName].push_back(connection);
+                    ePerfs.push_back(connection);
                 }
             }
             bool commit_wellstate = false;


### PR DESCRIPTION
In particular, switch to taking parameters as reference to `const` where possible, and return references where meaningful. Furthermore, construct objects in place where possible and reduce object scopes.