### PR TITLE
Collect Statistics on Connection Level Fracturing Process

### DIFF
--- a/opm/geomech/Fracture.cpp
+++ b/opm/geomech/Fracture.cpp
@@ -5,7 +5,9 @@
 #include <opm/geomech/Math.hpp>
 #include <opm/simulators/linalg/setupPropertyTree.hpp>
 #include <opm/simulators/linalg/FlowLinearSolverParameters.hpp>
+#include <opm/simulators/wells/ConnFracStatistics.hpp>
 #include <opm/simulators/wells/RuntimePerforation.hpp>
+
 #include <opm/geomech/DiscreteDisplacement.hpp>
 #include <dune/common/filledarray.hh> // needed for printSparseMatrix??
 #include <dune/istl/io.hh> // needed for printSparseMatrix??
@@ -1034,8 +1036,36 @@ std::vector<RuntimePerforation> Fracture::wellIndices() const{
     return wellIndices;
 }
 
-void
-Fracture::writePressureSystem() const{
+template <typename Scalar>
+void Fracture::assignGeomechWellState(ConnFracStatistics<Scalar>& stats) const
+{
+    using Quantity = typename ConnFracStatistics<Scalar>::Quantity;
+
+    constexpr auto pressIx = static_cast<std::underlying_type_t<Quantity>>(Quantity::Pressure);
+    constexpr auto rateIx  = static_cast<std::underlying_type_t<Quantity>>(Quantity::FlowRate);
+    constexpr auto widthIx = static_cast<std::underlying_type_t<Quantity>>(Quantity::Width);
+
+    const auto nCells = this->reservoir_cells_.size();
+
+    stats.reset();
+
+    for (auto cellIx = 0*nCells; cellIx < nCells; ++cellIx) {
+        auto samplePoint = typename ConnFracStatistics<Scalar>::SamplePoint{};
+
+        samplePoint[pressIx] = this->fracture_pressure_[cellIx][0];
+
+        samplePoint[rateIx] = this->leakof_[cellIx]
+            * (this->fracture_pressure_[cellIx][0] -
+               this->reservoir_pressure_[cellIx]);
+
+        samplePoint[widthIx] = this->fracture_width_[cellIx][0];
+
+        stats.addSamplePoint(samplePoint);
+    }
+}
+
+void Fracture::writePressureSystem() const
+{
     if(prm_.get<bool>("write_pressure_system")){
         Dune::storeMatrixMarket(*pressure_matrix_, "pressure_matrix");
         Dune::storeMatrixMarket(rhs_pressure_, "pressure_rhs");
@@ -1366,11 +1396,14 @@ void Fracture::printMechMatrix() const // debug purposes
 // }
 
 
-
 // template void
 // Fracture::updateReservoirCells<Dune::CpGrid>(const external::cvf::ref<external::cvf::BoundingBoxTree>& cellSearchTree,
 //                                              const Dune::CpGrid& grid3D);
 // template void
 // Fracture::updateReservoirCells<Dune::PolyhedralGrid<3,3,double>>(const external::cvf::ref<external::cvf::BoundingBoxTree>& cellSearchTree,
 //                                              const Dune::PolyhedralGrid<3,3,double>& grid3D);
+
+template void Fracture::assignGeomechWellState(ConnFracStatistics<float>&) const;
+template void Fracture::assignGeomechWellState(ConnFracStatistics<double>&) const;
+
 } // namespace Opm

--- a/opm/geomech/Fracture.hpp
+++ b/opm/geomech/Fracture.hpp
@@ -50,6 +50,11 @@
 
 #include <opm/geomech/GridStretcher.hpp>
 
+namespace Opm {
+    template <typename Scalar>
+    class ConnFracStatistics;
+}
+
 namespace Opm::Properties {
     template <class TypeTag, class MyType>
     struct FluidSystem;
@@ -170,12 +175,17 @@ public:
     void setFractureGrid(std::unique_ptr<Fracture::Grid> gptr = nullptr); // a hack to allow use of another grid
     std::vector<RuntimePerforation> wellIndices() const;
     WellInfo& wellInfo(){return wellinfo_;}
+    const WellInfo& wellInfo() const { return wellinfo_; }
     std::vector<double> leakOfRate() const;
     double injectionPressure() const;
     void setPerfPressure(double perfpressure){perf_pressure_ = perfpressure;}
     Dune::FieldVector<double, 6> stress(Dune::FieldVector<double, 3> obs) const;
     Dune::FieldVector<double, 6> strain(Dune::FieldVector<double, 3> obs) const;
-    Dune::FieldVector<double, 3> disp(Dune::FieldVector<double, 3> obs) const;  
+    Dune::FieldVector<double, 3> disp(Dune::FieldVector<double, 3> obs) const;
+
+    template <typename Scalar>
+    void assignGeomechWellState(ConnFracStatistics<Scalar>& stats) const;
+
 private:
 
     size_t numFractureCells() const { return grid_->leafGridView().size(0); }

--- a/opm/geomech/FractureModel.hpp
+++ b/opm/geomech/FractureModel.hpp
@@ -15,6 +15,9 @@
 
 namespace Opm {
     class RuntimePerforation;
+
+    template <typename Scalar>
+    class WellState;
 } // namespace Opm
 
 namespace Opm{
@@ -121,7 +124,13 @@ public:
              well.updateReservoirProperties<TypeTag,Simulator>(simulator);
         }
     }
-    std::vector<RuntimePerforation> getExtraWellIndices(const std::string& wellname) const;
+
+    std::vector<RuntimePerforation>
+    getExtraWellIndices(const std::string& wellname) const;
+
+    template <typename Scalar>
+    void assignGeomechWellState(WellState<Scalar>& wellState) const;
+
     bool addPertsToSchedule(){return prm_.get<bool>("addperfs_to_schedule");}
     // probably this should be collected in one loop since all do full loop over fracture ++ well
     Dune::FieldVector<double,6> stress(Dune::FieldVector<double,3> obs) const;

--- a/opm/geomech/eclproblemgeomech.hh
+++ b/opm/geomech/eclproblemgeomech.hh
@@ -263,6 +263,9 @@ namespace Opm{
                         assert(false);
                         this->addConnectionsToWell();
                     }
+
+                    this->geomechModel_.fractureModel()
+                        .assignGeomechWellState(this->wellModel_.wellState());
                 }
             }
             


### PR DESCRIPTION
This PR adds a new member function
```C++
template <typename Scalar>
void Fracture::assignGeomechWellState(ConnFracStatistics<Scalar>&) const;
```
which computes statistical measures (minimum value, maximum value, average value/mean, and standard deviation) of fracture pressures, injection flow rate, and fracture width for a single fracture.  We also add a new member function
```C++
template <typename Scalar>
void FractureModel::assignGeomechWellState(WellState<Scalar>& wellState) const;
```
which calls the above for each fracture in the model.  Collectively, these enable emitting the new summary vectors
```
CFR<Q>{MAX,MIN,AVG,STD}
```
introduced in PRs OPM/opm-common#4388 and OPM/opm-simulators#5811 for the quantity `<Q>` as 'P' (pressure), 'IR' (injection rate), and 'WD' (width) through the regular mechanism.