### PR TITLE
Use Well Fracturing Seeds From SCHEDULE Section

### DIFF
--- a/data/MECHTEST/SCHEDULE.TXT
+++ b/data/MECHTEST/SCHEDULE.TXT
@@ -22,6 +22,11 @@ WTEMP
    P1 30 /
 /
 
+WSEED
+-- Well  I  J  K  nx   ny   nz
+   P1   16 16  6  0.0  1.0  0.0 /
+/
+
 -- BC
 -- 1 1 1 31 1 10 X- FREE  WATER 3* FIXED 1 1 1 3*0 3*0/
 -- 31 31 1 31 1 10 X+ FREE WATER 3* FIXED 1 1 1 3*0 3*0/

--- a/dune.module
+++ b/dune.module
@@ -5,8 +5,8 @@
 
 Module: opm-flowgeomechanics
 Description: Simulators and utilities for automatic differentiation
-Version: 2025.04-pre
-Label: 2025.04-pre
+Version: 2025.10-pre
+Label: 2025.10-pre
 Maintainer: xxxx
 MaintainerName:xxxx
 Url: http://opm-project.org

--- a/opm/geomech/FractureModel_impl.hpp
+++ b/opm/geomech/FractureModel_impl.hpp
@@ -8,36 +8,6 @@ namespace Opm{
                   :
         prm_(param)
     {
-      using CartesianIndexMapper = Dune::CartesianIndexMapper<Grid>;
-      CartesianIndexMapper cartmapper(grid);
-      const auto& cartdim = cartmapper.cartesianDimensions();
-      std::vector<int> cart(cartdim[0]*cartdim[1]*cartdim[2], -1);
-      using ElementMapper = Dune::MultipleCodimMultipleGeomTypeMapper<typename Grid::LeafGridView>;
-      ElementMapper mapper(grid.leafGridView(), Dune::mcmgElementLayout());
-      for (const auto& elem : elements(grid.leafGridView())) {
-	int eIdx = mapper.index(elem);
-	cart[ cartmapper.cartesianIndex( eIdx ) ] = eIdx;
-      }
-      const auto& config = prm_.get_child("config");
-      std::string type = config.get<std::string>("type");
-      if( type  == "well_seed"){
-
-	const auto cell_ijk = config.get_child_items_as_vector<int>("cell_ijk");
-	std::array<int, 3> ijk;
-	   assert(cell_ijk.has_value() && cell_ijk->size() == 3);
-
-
-	for(int i=0; i < 3; ++i){
-	  // map to 0 based
-	  ijk[i] = (*cell_ijk)[i]-1;
-	}
-	int cartIdx =  ijk[0]+(cartdim[0])*ijk[1]+(cartdim[0]*cartdim[1])*ijk[2];//NB assumes ijk ordering
-	int reservoir_cell = cart[cartIdx];
-	assert(cartIdx>=0);
-	prm_.put("config.cell",reservoir_cell);
-      }
-      
-     
         //using CartesianIndexMapper = Dune::CartesianIndexMapper<Grid>;
         //CartesianIndexMapper cartmapper(grid);
         //const std::array<int, dimension>
@@ -80,11 +50,5 @@ namespace Opm{
         }
 
         external::buildBoundingBoxTree(cell_search_tree_, grid);
-    }
-  
-    template<class Grid>
-    void FractureModel::addDefaultsWells(const Grid& grid, const Opm::EclipseGrid& eclgrid) {
-      this->addFractures();
-      this->updateFractureReservoirCells();
     }
 }

--- a/opm/geomech/RegularTrimesh.cpp
+++ b/opm/geomech/RegularTrimesh.cpp
@@ -1,3 +1,5 @@
+#include <config.h>
+
 #include "RegularTrimesh.hpp"
 #include "GeometryHelpers.hpp"
 #include <algorithm>

--- a/opm/geomech/eclgeomechmodel.hh
+++ b/opm/geomech/eclgeomechmodel.hh
@@ -9,6 +9,9 @@
 #include <opm/geomech/FlowGeomechLinearSolverParameters.hpp>
 #include <opm/geomech/FractureModel.hpp>
 #include <opm/simulators/linalg/WriteSystemMatrixHelper.hpp>
+
+#include <opm/input/eclipse/Schedule/Schedule.hpp>
+
 namespace Opm{
     template<typename TypeTag>
     class EclGeoMechModel : public BaseAuxiliaryModule<TypeTag>
@@ -111,7 +114,7 @@ namespace Opm{
                     // most important stress
                     fracturemodel_->updateReservoirWellProperties<TypeTag,Simulator>(simulator_);
                     // add fractures along the wells
-                    fracturemodel_->addFractures();
+                    fracturemodel_->addFractures(schedule[reportStepIdx]);
 
                     fracturemodel_->updateFractureReservoirCells();
                     fracturemodel_->initReservoirProperties<TypeTag,Simulator>(simulator_);


### PR DESCRIPTION
This commit switches the "well_seed" fracture initialisation method to getting the seed point and associate fracturing plane normal vectors from the WSEED keyword in the SCHEDULE section.  At this time, there is an implicit assumption that the WSEED keyword is entered at the beginning of the SCHEDULE section, but we will relax this assumption in follow-up work.

As an aid to future development, we split each fracture initialisation method out to a separate member function and call the pertinent member function depending on the `PropertyTree`'s "fractureparam.config.type", with the "well_seed" method being the default.

Note that as the WSEED keyword is only available in 2025.10 and later, we also switch the minimum compatibility level to 2025.10-pre as part of this work.